### PR TITLE
Add registration spec pack v0.1 artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,21 @@
-# agentic-ai-pipeline-target-project-template
-Template for new projects that will be created by the Agentic AI Pipeline Coding Agent.
+# Customer Registration Module
+
+This repository contains the contract-first specification artifacts for the
+Customer Registration Module, derived from the PRD "Registration New Customer
+Accounts".
+
+## Spec Pack v0.1
+
+All deliverables for Task 1 are located in `docs/spec-pack/`:
+
+- Requirements Traceability Matrix: `docs/spec-pack/requirements-traceability-matrix.md`
+- OpenAPI specification: `docs/spec-pack/openapi.yaml`
+- JSON Schemas: `docs/spec-pack/schemas/`
+- Event Schemas: `docs/spec-pack/events/registration-events.md`
+- Acceptance Tests (Gherkin): `docs/spec-pack/tests/registration.feature`
+- NFR Budgets: `docs/spec-pack/nfr-budgets.md`
+- Observability Specification: `docs/spec-pack/observability.md`
+- Architectural Decision Records: `docs/spec-pack/adrs/`
+
+Use these artifacts as the contract for subsequent implementation, tooling, and
+review workflows.

--- a/docs/spec-pack/adrs/ADR-001-otp-channel-policy.md
+++ b/docs/spec-pack/adrs/ADR-001-otp-channel-policy.md
@@ -1,0 +1,31 @@
+# ADR-001: OTP Channel Policy
+
+- Status: Proposed
+- Date: 2025-10-06
+- Decision Makers: Security, App Engineering, Product
+
+## Context
+
+The PRD requires OTP verification during registration with support for email and
+SMS channels. We must define the default channel selection, fallback behavior,
+and guardrails for throttling and abuse controls.
+
+## Decision
+
+- Default OTP delivery channel is **email** for all regions where deliverability
+  meets the success SLO (≥ 98% within 60 seconds).
+- When a verified phone number is provided, the system offers SMS as a fallback
+  channel and allows the user to switch channels after two failed email attempts.
+- OTP resend is rate-limited to 1 request per 30 seconds and 5 per hour per
+  identifier; additional attempts trigger soft throttling with user messaging.
+- Administrative configuration allows per-region overrides to set SMS as default
+  when mandated by regulation or user behavior.
+
+## Consequences
+
+- Email infrastructure must integrate with high-reliability provider supporting
+  deliverability SLAs.
+- SMS costs are minimized by using fallback only when needed.
+- UI must present channel switching controls post-failure.
+- Monitoring must track per-channel success and error rates to validate the
+  fallback strategy.

--- a/docs/spec-pack/adrs/ADR-002-otp-code-policy.md
+++ b/docs/spec-pack/adrs/ADR-002-otp-code-policy.md
@@ -1,0 +1,29 @@
+# ADR-002: OTP Code Length and Expiry
+
+- Status: Proposed
+- Date: 2025-10-06
+- Decision Makers: Security, Compliance, App Engineering
+
+## Context
+
+We must select an OTP code length and expiry that balances usability, security,
+and regulatory expectations. The PRD leaves this open pending decision.
+
+## Decision
+
+- OTP codes will be **7 digits**, numeric only, providing 10 million combinations
+  and consistent UX across email and SMS.
+- Default code expiry (TTL) is **5 minutes** from issuance.
+- Codes become invalid immediately after a successful verification or when a new
+  code is issued.
+- Configuration range allows 3-10 minute TTL to satisfy region-specific policies.
+
+## Consequences
+
+- 7-digit codes maintain memorability while significantly reducing brute-force
+  success probability versus 6-digit alternatives.
+- Verification service must invalidate prior codes upon resend to avoid reuse.
+- UI copy must communicate the 5-minute window and avoid revealing remaining
+  validity time beyond countdown UI.
+- Monitoring must alert when verification latency approaches TTL to catch
+  deliverability issues.

--- a/docs/spec-pack/adrs/ADR-003-identifier-strategy.md
+++ b/docs/spec-pack/adrs/ADR-003-identifier-strategy.md
@@ -1,0 +1,30 @@
+# ADR-003: Customer Identifier Strategy
+
+- Status: Proposed
+- Date: 2025-10-06
+- Decision Makers: Product, Architecture, Data Privacy
+
+## Context
+
+The PRD confirms email as the primary identifier but leaves details of customer
+ID generation and duplicate handling open. We must ensure global uniqueness,
+privacy, and compatibility with downstream systems.
+
+## Decision
+
+- Customer Domain will issue a **surrogate customerId** (UUID v7) for every
+  successful registration.
+- Email remains the login identifier but is stored separately with normalization
+  (lowercased, trimmed) and hashed for dedupe comparisons.
+- Duplicate detection checks hashed email and optional hashed phone with leakage
+  guard messaging; conflicts return error `E_DUPLICATE`.
+- Downstream systems reference customers using `customerId` only; email/phone
+  shared via scoped data contracts.
+
+## Consequences
+
+- UUID v7 preserves ordering for analytics without exposing creation rate.
+- Requires hashing library consistent across services for dedupe.
+- Support tooling must map `customerId` to identifier data for legitimate
+  troubleshooting with appropriate permissions.
+- Analytics pipelines must join on `customerId`, not raw email.

--- a/docs/spec-pack/adrs/ADR-004-data-retention.md
+++ b/docs/spec-pack/adrs/ADR-004-data-retention.md
@@ -1,0 +1,29 @@
+# ADR-004: Registration Data Retention
+
+- Status: Proposed
+- Date: 2025-10-06
+- Decision Makers: Compliance, Data Privacy, App Engineering
+
+## Context
+
+We must define how long registration data, consent evidence, and telemetry are
+retained to satisfy legal obligations while minimizing exposure of PII.
+
+## Decision
+
+- Registration session data (including pending OTPs and resume tokens) is
+  retained for **72 hours** to align with decision D-003.
+- Successfully completed registration records are persisted indefinitely in the
+  Customer Domain but sensitive audit trails are stored separately with
+  retention policies.
+- Consent evidence (hash of consent copy, timestamp, jurisdiction, evidenceId) is
+  retained for **7 years** to meet marketing compliance requirements.
+- Telemetry logs containing pseudonymized identifiers are retained for 30 days
+  online and archived for 1 year with restricted access.
+
+## Consequences
+
+- Data retention jobs must purge expired registration sessions nightly.
+- Consent store requires lifecycle management with auditing to verify deletion.
+- Privacy reviews must ensure archived telemetry remains pseudonymized and access
+  is logged.

--- a/docs/spec-pack/events/registration-events.md
+++ b/docs/spec-pack/events/registration-events.md
@@ -1,0 +1,109 @@
+# Registration Event Schemas (CloudEvents-aligned)
+
+All events follow CloudEvents 1.0 structure with the following shared metadata:
+
+- `specversion`: `1.0`
+- `source`: `registration-service`
+- `type`: event-specific value (see below)
+- `id`: UUID v4
+- `subject`: `registration/{registrationId}` (unless noted)
+- `time`: ISO-8601 timestamp of emission
+- `datacontenttype`: `application/json`
+- `dataref`: Optional pointer to secure storage when payload is large
+- No raw PII outside hashed or tokenized fields; emails hashed with SHA-256 + salt.
+
+## Event: registration.started
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `registrationId` | string (uuid) | Correlates the session across services |
+| `emailHash` | string | SHA-256 hash of lowercased email with per-tenant salt |
+| `locale` | string | Locale requested by user |
+| `channelPreferences` | object | Primary/secondary OTP channels |
+| `initiatedBy` | string | Channel initiating the registration (web, mobile-web, support) |
+| `policyVersion` | string | Password/consent policy version snapshot |
+
+## Event: registration.otp_sent
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `registrationId` | string (uuid) | Registration session |
+| `channel` | string | `email` or `sms` |
+| `provider` | string | Downstream provider identifier |
+| `deliveryId` | string | Provider correlation ID |
+| `throttleState` | string | `normal`, `soft_block`, or `hard_block` |
+| `latencyMs` | integer | Time between request and provider acknowledgement |
+
+## Event: registration.otp_delivery_failed
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `registrationId` | string (uuid) | Session impacted |
+| `channel` | string | Delivery channel attempted |
+| `provider` | string | Provider identifier |
+| `reason` | string | Categorized failure reason (timeout, provider_error, invalid_destination) |
+| `retryEligible` | boolean | Indicates if auto-resend permitted |
+
+## Event: registration.otp_verified
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `registrationId` | string (uuid) | Session |
+| `method` | string | Channel used |
+| `verifiedAt` | string (date-time) | Timestamp verified |
+| `attempts` | integer | Number of attempts prior to success |
+
+## Event: registration.completed
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `registrationId` | string (uuid) | Session |
+| `customerId` | string | Newly created customer identifier (non-PII surrogate) |
+| `country` | string | Country code supplied |
+| `language` | string | Preferred language |
+| `marketingOptIn` | boolean | Marketing consent status |
+| `completionLatencyMs` | integer | Milliseconds between start and completion |
+
+## Event: registration.duplicate_detected
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `registrationId` | string (uuid) | Session |
+| `identifierType` | string | `email` or `phone` |
+| `leakageGuardLevel` | string | `none`, `low`, `high` |
+| `resolutionHint` | string | Recovery path recommended |
+
+## Event: registration.resumed
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `registrationId` | string (uuid) | Session |
+| `resumeTokenIssuedAt` | string (date-time) | When resume token issued |
+| `resumeChannel` | string | Channel used for resumption (email link, sms link, web cookie) |
+| `daysSinceStart` | integer | Age of registration |
+
+## Event: registration.throttled
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `registrationId` | string (uuid) | Optional if throttled before ID created |
+| `reason` | string | `otp_resend_limit`, `ip_velocity`, `device_velocity`, `abuse_block` |
+| `cooldownSeconds` | integer | Cooldown duration communicated |
+| `policyRef` | string | Identifier of throttling policy invoked |
+
+## Event: registration.abandoned
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `registrationId` | string (uuid) | Session |
+| `lastCompletedStep` | string | `start`, `otp`, `pii`, `consent` |
+| `inactiveDurationMinutes` | integer | Time since last activity |
+| `autoClosed` | boolean | Indicates if system expired session |
+
+### Event Validation
+
+- JSON payloads validated against JSON Schemas published alongside this document.
+- All events include `correlationId` and `traceId` for distributed tracing, derived
+  from the registration service's telemetry library.
+- Sensitive fields such as `emailHash` use salted hashing with rotation keyed by
+  `policyVersion`.

--- a/docs/spec-pack/nfr-budgets.md
+++ b/docs/spec-pack/nfr-budgets.md
@@ -1,0 +1,62 @@
+# Non-Functional Requirement Budgets
+
+This document codifies the measurable budgets for performance, reliability,
+security, accessibility, and compliance for the registration module.
+
+## Performance
+
+| Dimension | Target | Measurement Method | Notes |
+| --- | --- | --- | --- |
+| Registration API latency | p95 ≤ 300 ms, p99 ≤ 600 ms | Synthetic load test at 50 rps baseline; real-time metrics from API gateway | Includes `/register/start`, `/otp/send`, `/otp/verify`, `/register/complete` |
+| OTP send initiation | ≤ 500 ms p95 | Provider instrumentation + synthetic monitors | Fallback to alternate channel when > 500 ms for 3 consecutive minutes |
+| Front-end Time to Interactive | ≤ 3.0 s on 3G Fast profile | Lighthouse CI in pipeline | Leverage code-splitting, skeleton loading |
+| Database write throughput | 150 writes/sec sustained | Load test with failover | Budget aligns to growth forecasts + 2x headroom |
+
+## Reliability
+
+| Dimension | Target | Measurement | Notes |
+| --- | --- | --- | --- |
+| API availability | ≥ 99.9% monthly | SLO burn-rate alerts from SRE tooling | Circuit breakers for OTP provider |
+| OTP verification success | ≥ 95% daily | Ratio of successful `/otp/verify` to attempts | Investigate < 95% with root cause analysis |
+| OTP delivery success in 60s | ≥ 98% | Provider delivery receipts + synthetic monitors | Auto-switch to SMS if email fails per policy |
+| Registration completion rate | ≥ 70% (M30), ≥ 80% (M90) | Funnel metrics from analytics warehouse | Alerts when rolling 7-day average drops below thresholds |
+| Resume flow success | ≥ 90% of resume attempts complete | Tracking events vs errors | Drives FR-7 coverage |
+
+## Security
+
+| Control | Budget / Requirement | Validation |
+| --- | --- | --- |
+| Password policy | Min length 12, 1 upper, 1 lower, 1 digit, 1 symbol | Unit tests; policy linting; security review |
+| OTP code TTL | 5 minutes default, configurable 3-10 minutes | Config tests; ADR-002 | |
+| Rate limiting | `/register/start` 10/min per IP, `/otp/send` 5/hour per identifier | Gateway config + load tests |
+| Secrets handling | No credentials in code; use managed secret store | Static analysis; secrets scanning |
+| Logging | No PII beyond hashed identifiers; logs retained 30 days | Log lint + compliance review |
+
+## Compliance & Privacy
+
+| Control | Budget | Validation |
+| --- | --- | --- |
+| Consent evidence retention | 7 years (jurisdictional default) | Retention policy job; audit | Aligns with ADR-004 |
+| Data minimization | Collect only mandatory PII fields at registration | Schema lint; manual review | Additional fields gated via feature flags |
+| Data subject requests | Fulfill within 30 days | Ticket SLA reporting | Integration with Privacy team automation |
+
+## Accessibility
+
+| Metric | Budget | Validation |
+| --- | --- | --- |
+| Automated a11y violations | 0 critical, ≤ 5 minor per release | Axe CI + manual QA | Failure blocks release |
+| Keyboard navigation | 100% actionable controls reachable | Manual audit checklist each release | |
+| Color contrast | WCAG 2.1 AA compliance | Design system tokens check | |
+
+## Observability & Alerting Budgets
+
+- Error budget burn alerts at 2%, 5%, 10% of monthly budget with paging thresholds.
+- Funnel drop alerts when step-to-step conversion decreases by >5% within 1 hour.
+- OTP provider health check poll every 60 seconds with alert on 3 consecutive failures.
+
+## Disaster Recovery
+
+- RPO: ≤ 5 minutes (replicated database).
+- RTO: ≤ 30 minutes with automated redeploy + database failover scripts.
+
+These budgets align with SRE and compliance expectations for launch readiness.

--- a/docs/spec-pack/observability.md
+++ b/docs/spec-pack/observability.md
@@ -1,0 +1,98 @@
+# Observability Specification
+
+This specification defines the metrics, logs, dashboards, and alerts needed to
+observe the registration experience end-to-end.
+
+## Metrics
+
+| Metric Name | Type | Description | Dimensions | Owner |
+| --- | --- | --- | --- | --- |
+| registration.start.count | Counter | Number of `/register/start` requests accepted | environment, clientId, locale | App Engineering |
+| registration.complete.count | Counter | Successful completions | environment, locale, marketingOptIn | Product Analytics |
+| registration.start_to_complete.rate | Gauge | Rolling conversion rate | environment, locale | Growth PM |
+| otp.delivery.latency.p95 | Gauge | P95 OTP delivery latency in ms | environment, channel, provider | SRE |
+| otp.delivery.success.rate | Gauge | % OTP sends acknowledged within 60s | environment, channel, provider | SRE |
+| otp.verify.success.rate | Gauge | Ratio of successful `/otp/verify` to total attempts | environment, channel | Security |
+| registration.form.field_error_rate | Gauge | Validation error rate per field | environment, field | UX |
+| registration.resume.success_rate | Gauge | % resumes that reach completion | environment | Product Analytics |
+| a11y.violations.count | Counter | Accessibility violations from CI | environment, severity | QA |
+| security.anomaly.count | Counter | Alerts from anomaly detection (brute force, velocity) | environment, anomaly_type | Security |
+
+Metrics emitted via OpenTelemetry to centralized metrics backend (Prometheus +
+Grafana). Retention: 30 days high-resolution, 13 months roll-up.
+
+## Logs
+
+- Structured JSON logs with fields: `timestamp`, `level`, `message`,
+  `registrationId`, `correlationId`, `clientId`, `ipHash`, `eventType`,
+  `latencyMs`, `errorCode`.
+- PII fields hashed (SHA-256 + salt) or redacted at source.
+- Logs shipped to centralized logging (Elastic/Cloud Logging) with 30-day
+  retention, archived to cold storage for 1 year for compliance.
+- Security-relevant events flagged with `securityEvent=true` for SIEM ingestion.
+
+## Tracing
+
+- Distributed tracing via OpenTelemetry, trace sampled at 20% baseline, 100% for
+  errors and throttled responses.
+- Span names: `register.start`, `otp.send`, `otp.verify`, `register.complete`.
+- Attributes include `clientId`, `locale`, `channel`, `throttleState`, `retryCount`.
+
+## Dashboards
+
+1. **Registration Funnel Dashboard** (Product Analytics)
+   - Conversion from start → OTP verified → completed.
+   - Drop-off by locale, device type.
+   - Median and p95 completion time.
+
+2. **OTP Health Dashboard** (SRE/Security)
+   - Delivery success and latency per channel/provider.
+   - Error codes distribution.
+   - Rate-limit utilization and throttled counts.
+
+3. **Reliability Dashboard** (SRE)
+   - API availability vs SLO.
+  - 5xx error trends and burn-rate gauges.
+   - Queue depth or retry backlog for OTP provider.
+
+4. **Accessibility & Compliance Dashboard** (QA/Compliance)
+   - a11y violation counts from CI.
+   - Consent logging completeness.
+   - Data retention job success/failure metrics.
+
+Dashboards implemented in Grafana with templating for environment (prod, staging,
+perf). Access restricted by role-based access control.
+
+## Alerts
+
+- **Conversion Drop Alert**: Trigger when `registration.start_to_complete.rate`
+  decreases by >5 percentage points within 1 hour. PagerDuty: Product Analytics.
+- **OTP Delivery Latency Alert**: Trigger when `otp.delivery.latency.p95` > 500 ms
+  for 5 minutes. PagerDuty: SRE on-call.
+- **OTP Delivery Failure Alert**: Trigger when `otp.delivery.success.rate` < 98%
+  for 10 minutes. PagerDuty: SRE + Security.
+- **Rate Limit Abuse Alert**: Trigger on spike of `security.anomaly.count`
+  indicating possible OTP abuse (threshold 3x baseline). PagerDuty: Security.
+- **Availability Alert**: Trigger when API availability burn rate predicts SLO
+  exhaustion within 2 hours. PagerDuty: SRE.
+- **Accessibility Regression Alert**: Trigger when `a11y.violations.count`
+  > 0 critical in CI. Slack notification to QA + App Eng.
+
+## Synthetic Monitoring
+
+- Journey monitors from 3 geographic regions hitting staging environment every 5
+  minutes.
+- Steps: start registration → request OTP → poll for email OTP via test harness →
+  verify → complete.
+- Validate that required events land in analytics pipeline within 5 minutes.
+
+## Runbooks
+
+- OTP Provider Degradation Runbook: steps to failover to alternate channel,
+  contact provider, adjust rate limits.
+- Duplicate Detection Tuning Runbook: adjust thresholds, review false positives.
+- Consent Evidence Gap Runbook: manual ingestion process when audit detects
+  missing evidence.
+
+Runbooks stored in internal wiki, referenced in alert descriptions for quick
+access.

--- a/docs/spec-pack/openapi.yaml
+++ b/docs/spec-pack/openapi.yaml
@@ -1,0 +1,533 @@
+openapi: 3.1.0
+info:
+  title: Customer Registration API
+  version: 0.1.0
+  description: |
+    Contract-first API definition for the customer registration module.
+    Implements FR-1 through FR-7 of the PRD with consistent error and
+    observability headers.
+servers:
+  - url: https://api.example.com
+    description: Production gateway
+  - url: https://staging-api.example.com
+    description: Staging environment
+security:
+  - RateLimitToken: []
+  - ClientId: []
+paths:
+  /register/start:
+    post:
+      summary: Start registration with email and password
+      operationId: startRegistration
+      tags: [Registration]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RegisterStartRequest'
+      responses:
+        '202':
+          description: Registration started, OTP verification required
+          headers:
+            X-Registration-Id:
+              description: Correlation ID for registration session
+              schema:
+                type: string
+                format: uuid
+            X-Next-Step:
+              description: Next action required by the client
+              schema:
+                type: string
+                enum: [otp_required]
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RegisterStartResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '409':
+          $ref: '#/components/responses/Duplicate'
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
+  /otp/send:
+    post:
+      summary: Send OTP via email or SMS
+      operationId: sendOtp
+      tags: [Registration, OTP]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OtpSendRequest'
+      responses:
+        '204':
+          description: OTP sent successfully
+          headers:
+            X-RateLimit-Remaining:
+              description: Remaining OTP sends allowed in the current window
+              schema:
+                type: integer
+            Retry-After:
+              description: Seconds until the next send is allowed when throttled
+              schema:
+                type: integer
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '404':
+          description: Registration session not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '409':
+          description: Registration already verified or completed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
+  /otp/verify:
+    post:
+      summary: Verify a one-time passcode
+      operationId: verifyOtp
+      tags: [Registration, OTP]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OtpVerifyRequest'
+      responses:
+        '200':
+          description: OTP validated and registration unlocked
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OtpVerifyResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          description: OTP incorrect or expired
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: Registration session not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
+  /register/complete:
+    post:
+      summary: Complete registration with personal data, consent, and preferences
+      operationId: completeRegistration
+      tags: [Registration]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RegisterCompleteRequest'
+      responses:
+        '201':
+          description: Customer created successfully
+          headers:
+            X-Customer-Id:
+              description: Newly created customer identifier
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RegisterCompleteResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          description: Registration not verified
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '409':
+          $ref: '#/components/responses/Duplicate'
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
+  /register/status:
+    get:
+      summary: Retrieve current registration state for resumption
+      operationId: getRegistrationStatus
+      tags: [Registration]
+      parameters:
+        - name: registrationId
+          in: query
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: Current registration state
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RegisterStatusResponse'
+        '404':
+          description: Registration session not found or expired
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /register/resume:
+    patch:
+      summary: Resume an incomplete registration with updated data
+      operationId: resumeRegistration
+      tags: [Registration]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RegisterResumeRequest'
+      responses:
+        '200':
+          description: Registration resumed and latest state returned
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RegisterStatusResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '404':
+          description: Registration session not found or expired
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '409':
+          description: Registration already completed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+components:
+  securitySchemes:
+    RateLimitToken:
+      type: apiKey
+      in: header
+      name: X-RateLimit-Token
+      description: Token used to allocate rate limit buckets per partner/client
+    ClientId:
+      type: apiKey
+      in: header
+      name: X-Client-Id
+      description: Static client identifier issued to registered applications
+  responses:
+    BadRequest:
+      description: Validation or policy error
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+    Duplicate:
+      description: Duplicate customer detected
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: '#/components/schemas/ErrorResponse'
+              - type: object
+                properties:
+                  error:
+                    properties:
+                      code:
+                        enum: [E_DUPLICATE]
+                      hint:
+                        description: Safe messaging to guide user to recovery
+                        type: string
+    TooManyRequests:
+      description: Throttled due to rate limits or abuse controls
+      headers:
+        Retry-After:
+          description: Seconds until the client may retry
+          schema:
+            type: integer
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+  schemas:
+    ErrorResponse:
+      type: object
+      required: [error]
+      properties:
+        error:
+          type: object
+          required: [code, message]
+          properties:
+            code:
+              type: string
+              description: Machine-readable error code
+            message:
+              type: string
+              description: Localizable error summary
+            fieldErrors:
+              type: array
+              items:
+                type: object
+                required: [field, message]
+                properties:
+                  field:
+                    type: string
+                  message:
+                    type: string
+            correlationId:
+              type: string
+              description: Log correlation identifier
+    RegisterStartRequest:
+      type: object
+      required: [email, password, locale, channelPreferences]
+      properties:
+        email:
+          $ref: '#/components/schemas/Email'
+        password:
+          $ref: '#/components/schemas/Password'
+        locale:
+          $ref: '#/components/schemas/Locale'
+        channelPreferences:
+          type: object
+          description: Preferred OTP delivery channels ranked
+          properties:
+            primary:
+              $ref: '#/components/schemas/OtpChannel'
+            secondary:
+              $ref: '#/components/schemas/OtpChannel'
+        metadata:
+          type: object
+          additionalProperties:
+            type: string
+          description: Optional partner-specific metadata captured at start
+    RegisterStartResponse:
+      type: object
+      required: [registrationId, nextStep, expiresAt]
+      properties:
+        registrationId:
+          type: string
+          format: uuid
+        nextStep:
+          type: string
+          enum: [otp_required]
+        expiresAt:
+          type: string
+          format: date-time
+        otp:
+          type: object
+          properties:
+            channel:
+              $ref: '#/components/schemas/OtpChannel'
+            expirySeconds:
+              type: integer
+    OtpSendRequest:
+      type: object
+      required: [registrationId, channel]
+      properties:
+        registrationId:
+          type: string
+          format: uuid
+        channel:
+          $ref: '#/components/schemas/OtpChannel'
+        resend:
+          type: boolean
+          default: false
+        locale:
+          $ref: '#/components/schemas/Locale'
+    OtpVerifyRequest:
+      type: object
+      required: [registrationId, code]
+      properties:
+        registrationId:
+          type: string
+          format: uuid
+        code:
+          type: string
+          minLength: 6
+          maxLength: 8
+          pattern: '^[0-9]{6,8}$'
+        channel:
+          $ref: '#/components/schemas/OtpChannel'
+    OtpVerifyResponse:
+      type: object
+      required: [registrationId, status]
+      properties:
+        registrationId:
+          type: string
+          format: uuid
+        status:
+          type: string
+          enum: [verified, already_verified]
+        verifiedAt:
+          type: string
+          format: date-time
+    RegisterCompleteRequest:
+      type: object
+      required: [registrationId, personal, consent, preferences]
+      properties:
+        registrationId:
+          type: string
+          format: uuid
+        personal:
+          $ref: '#/components/schemas/PersonalInfo'
+        consent:
+          $ref: '#/components/schemas/ConsentRecord'
+        preferences:
+          $ref: '#/components/schemas/PreferenceRecord'
+        marketingOptInEvidence:
+          type: string
+          description: Hash of consent text shown to user for audit
+        deviceFingerprint:
+          type: string
+          description: Optional device fingerprint token for risk checks
+    RegisterCompleteResponse:
+      type: object
+      required: [customerId, registrationId, status]
+      properties:
+        customerId:
+          type: string
+        registrationId:
+          type: string
+          format: uuid
+        status:
+          type: string
+          enum: [completed]
+        createdAt:
+          type: string
+          format: date-time
+    RegisterStatusResponse:
+      type: object
+      required: [registrationId, status, step, expiresAt]
+      properties:
+        registrationId:
+          type: string
+          format: uuid
+        status:
+          type: string
+          enum: [pending, verified, completed, expired]
+        step:
+          type: string
+          enum: [start, otp_required, otp_verified, complete]
+        expiresAt:
+          type: string
+          format: date-time
+        lastUpdatedAt:
+          type: string
+          format: date-time
+    RegisterResumeRequest:
+      type: object
+      required: [registrationId]
+      properties:
+        registrationId:
+          type: string
+          format: uuid
+        personal:
+          $ref: '#/components/schemas/PersonalInfo'
+        preferences:
+          $ref: '#/components/schemas/PreferenceRecord'
+        consent:
+          $ref: '#/components/schemas/ConsentRecord'
+    PersonalInfo:
+      type: object
+      required: [firstName, lastName, country, language]
+      properties:
+        firstName:
+          type: string
+          maxLength: 100
+        lastName:
+          type: string
+          maxLength: 100
+        country:
+          type: string
+          minLength: 2
+          maxLength: 2
+        language:
+          $ref: '#/components/schemas/Locale'
+        phone:
+          type: string
+          pattern: '^\+?[0-9]{7,15}$'
+        birthDate:
+          type: string
+          format: date
+        address:
+          $ref: '#/components/schemas/PostalAddress'
+    PostalAddress:
+      type: object
+      properties:
+        line1:
+          type: string
+          maxLength: 200
+        line2:
+          type: string
+          maxLength: 200
+        city:
+          type: string
+          maxLength: 120
+        region:
+          type: string
+          maxLength: 120
+        postalCode:
+          type: string
+          maxLength: 20
+    ConsentRecord:
+      type: object
+      required: [marketing, timestamp, jurisdiction]
+      properties:
+        marketing:
+          type: boolean
+        timestamp:
+          type: string
+          format: date-time
+        jurisdiction:
+          type: string
+        ipAddress:
+          type: string
+          format: ipv4
+        userAgent:
+          type: string
+        evidenceId:
+          type: string
+    PreferenceRecord:
+      type: object
+      properties:
+        commsChannel:
+          type: string
+          enum: [email, sms, none]
+        language:
+          $ref: '#/components/schemas/Locale'
+        newsletterTopics:
+          type: array
+          items:
+            type: string
+    Password:
+      type: string
+      minLength: 12
+      pattern: '^(?=.*[A-Z])(?=.*[a-z])(?=.*[0-9])(?=.*[^A-Za-z0-9]).{12,}$'
+      description: Strong password policy aligned with Security guidance
+    Email:
+      type: string
+      format: email
+      maxLength: 254
+    Locale:
+      type: string
+      example: en-US
+    OtpChannel:
+      type: string
+      enum: [email, sms]
+    RegistrationStateToken:
+      type: string
+      description: Signed token representing registration state
+

--- a/docs/spec-pack/requirements-traceability-matrix.md
+++ b/docs/spec-pack/requirements-traceability-matrix.md
@@ -1,0 +1,33 @@
+# Requirements Traceability Matrix (RTM)
+
+This matrix maps every functional and non-functional requirement from the PRD to the
+contracts, validations, and quality signals that ensure the requirement is implemented
+and verifiable.
+
+| Requirement ID | Description | Contracts / APIs / Schemas | Tests | Metrics & Alerts |
+| --- | --- | --- | --- | --- |
+| FR-1 | Account creation with email and password | POST `/register/start`, `RegisterStartRequest` & `RegisterStartResponse` schemas; PasswordPolicy schema; CustomerIdentifier schema | Gherkin S1.1 Happy Path; Unit tests for password policy + registration ID generation; Integration test for database persistence | Funnel metric `registration.start.count`; `registration.start_to_complete.rate`; Alert on 5xx > 0.2% |
+| FR-2 | Two-factor verification at registration | POST `/otp/send`, `/otp/verify`; `OtpSendRequest`, `OtpVerifyRequest`; OTPPolicy schema; OTP event schemas | Gherkin S1.2 OTP Send, S1.3 OTP Verify; Unit tests for code generation and expiry; Resiliency tests for degraded provider | Metric `otp.delivery.latency.p95`; Alert on delivery success < 98% or verification success < 95%; Throttling rate |
+| FR-3 | Personal information capture | POST `/register/complete`; `RegisterCompleteRequest` & Response; PersonalInfo schema | Gherkin S1.4 Complete Registration; Unit tests for validation + localization; Accessibility tests for form fields | Metric `registration.form.field_error_rate`; `registration.complete.count`; Alert on validation error spikes |
+| FR-4 | Preferences and consent capture | POST `/register/complete`; Consent schema; Preferences schema; Consent event | Gherkin S1.5 Consent Required; Unit tests for timestamp/logging; Audit log integration tests | Metric `registration.consent.opt_in.rate`; Alert if consent missing vs jurisdiction policy |
+| FR-5 | Duplicate detection and recovery | Error model `E_DUPLICATE`; GET `/register/status` duplicate flag; DuplicateHandling schema | Gherkin S2.1 Duplicate Attempt; Unit tests for dedupe logic; E2E test for safe messaging | Metric `registration.duplicate.attempt_rate`; Alert if leakage guard fails audit |
+| FR-6 | Resend and retry policies | POST `/otp/send` rate limit headers + resend policy schema | Gherkin S2.2 Resend with Backoff; Load test for throttling; Unit tests for rate limit counters | Metric `otp.resend.count`; Alert on resend above threshold / rate limit breach |
+| FR-7 | Session and state continuity | GET `/register/status`; PATCH `/register/resume`; RegistrationState schema | Gherkin S3.1 Resume Registration; Unit test for state expiry; Integration test for secure token storage | Metric `registration.resume.success_rate`; Alert if resume errors > 1% |
+| FR-8 | Audit and analytics events | Event schemas `registration.started/completed/throttled/...`; Logging contracts | Gherkin S4.1 Audit Trail; Unit tests for event emission; Synthetic monitoring verifying instrumentation | Metrics `registration.event.emit.success_rate`; Alert on missing events within 5m lag |
+| FR-9 | Administrative observability | Observability spec dashboards; Metrics API; Audit views | Operational runbooks acceptance tests; Dashboard snapshot review; Synthetic monitoring for metrics | Metrics enumerated in Observability spec; Alerts per KPI thresholds |
+| FR-10 | Accessibility and localization | Front-end component contract; i18n JSON schema; Accessibility checklist | Gherkin S5.1 Accessibility; Automated a11y suite; Manual audits | Metric `a11y.violations.count`; Alert when >0 critical in CI |
+| NFR-Performance | Page TTI, API latency budgets | Performance budgets doc; Load test profiles; OpenAPI rate-limit headers | Load tests (k6) hitting SLO thresholds; Browser performance tests | Metric `registration.api.latency.p95`; `tti.mobile.p95`; Alerts on SLO breaches |
+| NFR-Reliability | Availability targets, graceful degradation | Error model, retry policy contracts, circuit breaker configuration | Chaos tests for OTP provider; Resiliency drills; Synthetic uptime checks | Metrics `registration.api.availability`; Alert when availability < 99.9% |
+| NFR-Security | MFA enforcement, password policy, rate limiting | Security headers spec; PasswordPolicy schema; RateLimitToken header | STRIDE threat model validation; Static analysis; Pen-test findings tracked | Metrics `security.anomaly.count`; Alert on repeated OTP failures / brute force |
+| NFR-Compliance | Consent logging, retention policy | Data retention ADR; Consent schema; Audit log storage contract | Compliance checklist; Audit log verification tests | Metrics `consent.record.missing.rate`; Alert when >0 |
+| NFR-Accessibility | WCAG adherence | Accessibility test charter; UI component specs | Axe automated tests; Manual audits; Keyboard navigation tests | Metric `a11y.critical_defects`; Alert triggered in CI pipeline |
+| NFR-Privacy | Data minimization, encryption | Data classification matrix; PII handling spec | Security unit tests; Encryption configuration validation; Data retention tests | Metric `pii.access.anomaly`; Alert on unauthorized access events |
+| NFR-Internationalization | Locale support and readiness | Locale resource schema; Copy externalization process | Localization lint; Snapshot tests per locale | Metric `locale.coverage`; Alert on missing translations in CI |
+
+## Traceability Notes
+
+- Each requirement links to at least one automated test and observable metric.
+- Security and compliance requirements integrate with central governance tooling via the
+  observability and audit specifications.
+- Contracts reference schemas in `docs/spec-pack/schemas/` and events in
+  `docs/spec-pack/events/`.

--- a/docs/spec-pack/schemas/otp-send-request.schema.json
+++ b/docs/spec-pack/schemas/otp-send-request.schema.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.com/schemas/otp-send-request.json",
+  "title": "OtpSendRequest",
+  "type": "object",
+  "required": ["registrationId", "channel"],
+  "properties": {
+    "registrationId": {
+      "type": "string",
+      "format": "uuid"
+    },
+    "channel": {
+      "enum": ["email", "sms"]
+    },
+    "resend": {
+      "type": "boolean",
+      "default": false
+    },
+    "locale": {
+      "type": "string",
+      "pattern": "^[a-z]{2}-[A-Z]{2}$"
+    }
+  },
+  "additionalProperties": false
+}

--- a/docs/spec-pack/schemas/otp-verify-request.schema.json
+++ b/docs/spec-pack/schemas/otp-verify-request.schema.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.com/schemas/otp-verify-request.json",
+  "title": "OtpVerifyRequest",
+  "type": "object",
+  "required": ["registrationId", "code"],
+  "properties": {
+    "registrationId": {
+      "type": "string",
+      "format": "uuid"
+    },
+    "code": {
+      "type": "string",
+      "pattern": "^[0-9]{6,8}$"
+    },
+    "channel": {
+      "enum": ["email", "sms"]
+    }
+  },
+  "additionalProperties": false
+}

--- a/docs/spec-pack/schemas/otp-verify-response.schema.json
+++ b/docs/spec-pack/schemas/otp-verify-response.schema.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.com/schemas/otp-verify-response.json",
+  "title": "OtpVerifyResponse",
+  "type": "object",
+  "required": ["registrationId", "status", "verifiedAt"],
+  "properties": {
+    "registrationId": {
+      "type": "string",
+      "format": "uuid"
+    },
+    "status": {
+      "enum": ["verified", "already_verified"]
+    },
+    "verifiedAt": {
+      "type": "string",
+      "format": "date-time"
+    }
+  },
+  "additionalProperties": false
+}

--- a/docs/spec-pack/schemas/register-complete-request.schema.json
+++ b/docs/spec-pack/schemas/register-complete-request.schema.json
@@ -1,0 +1,144 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.com/schemas/register-complete-request.json",
+  "title": "RegisterCompleteRequest",
+  "type": "object",
+  "required": ["registrationId", "personal", "consent", "preferences"],
+  "properties": {
+    "registrationId": {
+      "type": "string",
+      "format": "uuid"
+    },
+    "personal": {
+      "$ref": "#/definitions/PersonalInfo"
+    },
+    "consent": {
+      "$ref": "#/definitions/ConsentRecord"
+    },
+    "preferences": {
+      "$ref": "#/definitions/PreferenceRecord"
+    },
+    "marketingOptInEvidence": {
+      "type": "string",
+      "maxLength": 255
+    },
+    "deviceFingerprint": {
+      "type": "string",
+      "maxLength": 255
+    }
+  },
+  "definitions": {
+    "PersonalInfo": {
+      "type": "object",
+      "required": ["firstName", "lastName", "country", "language"],
+      "properties": {
+        "firstName": {
+          "type": "string",
+          "maxLength": 100
+        },
+        "lastName": {
+          "type": "string",
+          "maxLength": 100
+        },
+        "country": {
+          "type": "string",
+          "pattern": "^[A-Z]{2}$"
+        },
+        "language": {
+          "type": "string",
+          "pattern": "^[a-z]{2}-[A-Z]{2}$"
+        },
+        "phone": {
+          "type": "string",
+          "pattern": "^\\+?[0-9]{7,15}$"
+        },
+        "birthDate": {
+          "type": "string",
+          "format": "date"
+        },
+        "address": {
+          "$ref": "#/definitions/PostalAddress"
+        }
+      },
+      "additionalProperties": false
+    },
+    "PostalAddress": {
+      "type": "object",
+      "properties": {
+        "line1": {
+          "type": "string",
+          "maxLength": 200
+        },
+        "line2": {
+          "type": "string",
+          "maxLength": 200
+        },
+        "city": {
+          "type": "string",
+          "maxLength": 120
+        },
+        "region": {
+          "type": "string",
+          "maxLength": 120
+        },
+        "postalCode": {
+          "type": "string",
+          "maxLength": 20
+        }
+      },
+      "additionalProperties": false
+    },
+    "ConsentRecord": {
+      "type": "object",
+      "required": ["marketing", "timestamp", "jurisdiction"],
+      "properties": {
+        "marketing": {
+          "type": "boolean"
+        },
+        "timestamp": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "jurisdiction": {
+          "type": "string",
+          "maxLength": 10
+        },
+        "ipAddress": {
+          "type": "string",
+          "format": "ipv4"
+        },
+        "userAgent": {
+          "type": "string",
+          "maxLength": 500
+        },
+        "evidenceId": {
+          "type": "string",
+          "maxLength": 100
+        }
+      },
+      "additionalProperties": false
+    },
+    "PreferenceRecord": {
+      "type": "object",
+      "properties": {
+        "commsChannel": {
+          "enum": ["email", "sms", "none"]
+        },
+        "language": {
+          "type": "string",
+          "pattern": "^[a-z]{2}-[A-Z]{2}$"
+        },
+        "newsletterTopics": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "maxLength": 60
+          },
+          "maxItems": 10
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/docs/spec-pack/schemas/register-complete-response.schema.json
+++ b/docs/spec-pack/schemas/register-complete-response.schema.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.com/schemas/register-complete-response.json",
+  "title": "RegisterCompleteResponse",
+  "type": "object",
+  "required": ["customerId", "registrationId", "status", "createdAt"],
+  "properties": {
+    "customerId": {
+      "type": "string",
+      "maxLength": 64
+    },
+    "registrationId": {
+      "type": "string",
+      "format": "uuid"
+    },
+    "status": {
+      "enum": ["completed"]
+    },
+    "createdAt": {
+      "type": "string",
+      "format": "date-time"
+    }
+  },
+  "additionalProperties": false
+}

--- a/docs/spec-pack/schemas/register-resume-request.schema.json
+++ b/docs/spec-pack/schemas/register-resume-request.schema.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.com/schemas/register-resume-request.json",
+  "title": "RegisterResumeRequest",
+  "type": "object",
+  "required": ["registrationId"],
+  "properties": {
+    "registrationId": {
+      "type": "string",
+      "format": "uuid"
+    },
+    "personal": {
+      "$ref": "register-complete-request.schema.json#/definitions/PersonalInfo"
+    },
+    "preferences": {
+      "$ref": "register-complete-request.schema.json#/definitions/PreferenceRecord"
+    },
+    "consent": {
+      "$ref": "register-complete-request.schema.json#/definitions/ConsentRecord"
+    }
+  },
+  "additionalProperties": false
+}

--- a/docs/spec-pack/schemas/register-start-request.schema.json
+++ b/docs/spec-pack/schemas/register-start-request.schema.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.com/schemas/register-start-request.json",
+  "title": "RegisterStartRequest",
+  "type": "object",
+  "required": ["email", "password", "locale", "channelPreferences"],
+  "properties": {
+    "email": {
+      "type": "string",
+      "format": "email",
+      "maxLength": 254
+    },
+    "password": {
+      "type": "string",
+      "minLength": 12,
+      "pattern": "^(?=.*[A-Z])(?=.*[a-z])(?=.*[0-9])(?=.*[^A-Za-z0-9]).{12,}$"
+    },
+    "locale": {
+      "type": "string",
+      "pattern": "^[a-z]{2}-[A-Z]{2}$",
+      "examples": ["en-US"]
+    },
+    "channelPreferences": {
+      "type": "object",
+      "properties": {
+        "primary": {
+          "enum": ["email", "sms"]
+        },
+        "secondary": {
+          "enum": ["email", "sms", null]
+        }
+      },
+      "required": ["primary"],
+      "additionalProperties": false
+    },
+    "metadata": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string",
+        "maxLength": 200
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/docs/spec-pack/schemas/register-start-response.schema.json
+++ b/docs/spec-pack/schemas/register-start-response.schema.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.com/schemas/register-start-response.json",
+  "title": "RegisterStartResponse",
+  "type": "object",
+  "required": ["registrationId", "nextStep", "expiresAt"],
+  "properties": {
+    "registrationId": {
+      "type": "string",
+      "format": "uuid"
+    },
+    "nextStep": {
+      "type": "string",
+      "enum": ["otp_required"]
+    },
+    "expiresAt": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "otp": {
+      "type": "object",
+      "required": ["channel", "expirySeconds"],
+      "properties": {
+        "channel": {
+          "enum": ["email", "sms"]
+        },
+        "expirySeconds": {
+          "type": "integer",
+          "minimum": 60,
+          "maximum": 900
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/docs/spec-pack/schemas/register-status-response.schema.json
+++ b/docs/spec-pack/schemas/register-status-response.schema.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.com/schemas/register-status-response.json",
+  "title": "RegisterStatusResponse",
+  "type": "object",
+  "required": ["registrationId", "status", "step", "expiresAt", "lastUpdatedAt"],
+  "properties": {
+    "registrationId": {
+      "type": "string",
+      "format": "uuid"
+    },
+    "status": {
+      "enum": ["pending", "verified", "completed", "expired"]
+    },
+    "step": {
+      "enum": ["start", "otp_required", "otp_verified", "complete"]
+    },
+    "expiresAt": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "lastUpdatedAt": {
+      "type": "string",
+      "format": "date-time"
+    }
+  },
+  "additionalProperties": false
+}

--- a/docs/spec-pack/tests/registration.feature
+++ b/docs/spec-pack/tests/registration.feature
@@ -1,0 +1,55 @@
+Feature: Customer Registration
+  The registration service must guide a new customer from initial signup
+  through OTP verification, consent capture, and account creation while
+  enforcing security and compliance guardrails.
+
+  Background:
+    Given the registration service is healthy
+    And the OTP provider is available
+
+  @happy_path @fr1 @fr2 @fr3 @fr4
+  Scenario: Happy path with email OTP
+    When a user starts registration with valid email "user@example.com" and strong password
+    And the user requests an email OTP
+    And the user receives the OTP within 60 seconds
+    And the user verifies the OTP correctly on the first attempt
+    And the user submits the required personal information and consent
+    Then the system creates a customer record
+    And the registration.completed event is emitted with marketingOptIn false by default
+
+  @otp_resend @fr6
+  Scenario: OTP resend with backoff
+    Given a user has started registration and requested an email OTP
+    When the user requests another OTP within the cooldown window
+    Then the service denies the request with error code "E_RATE_LIMIT"
+    And the response includes Retry-After header greater than 0
+    When the cooldown expires and the user requests again
+    Then the OTP is sent successfully
+
+  @duplicate @fr5
+  Scenario: Duplicate identifier detected
+    Given an existing customer with email "dup@example.com"
+    When a new registration is started with the same email
+    Then the service responds with error code "E_DUPLICATE"
+    And the error message directs the user to the sign-in flow without confirming the account exists
+
+  @resume @fr7
+  Scenario: Resume registration within window
+    Given a registration started 24 hours ago and is pending OTP verification
+    When the user provides a valid resume token
+    Then the service returns the registration status with step "otp_required"
+    And the user can continue without re-entering personal information
+
+  @consent @fr4 @nfr_compliance
+  Scenario: Consent required for marketing opt-in jurisdiction
+    Given the jurisdiction requires explicit opt-in for marketing
+    When the user submits the registration without checking the marketing consent box
+    Then the submission is rejected with field error on "consent.marketing"
+    And no registration.completed event is emitted
+
+  @accessibility @fr10 @nfr_accessibility
+  Scenario: Accessibility validation
+    Given the registration UI is rendered in headless browser
+    When automated accessibility checks are run
+    Then there are no critical WCAG 2.1 AA violations
+    And all form controls are reachable via keyboard navigation


### PR DESCRIPTION
## Summary
- add the requirements traceability matrix, acceptance tests, and observability specification for the customer registration module
- publish the contract-first API specification with supporting JSON schemas and event definitions
- document key architectural decisions along with performance, security, and compliance budgets

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e5356d5610832d887e31eb546a2669